### PR TITLE
xSE PluginPreloader.xml: Cleanup leading whitespace

### DIFF
--- a/Build/xSE PluginPreloader.xml
+++ b/Build/xSE PluginPreloader.xml
@@ -6,11 +6,11 @@
 			If you have a mod that uses the same DLL as the preloader, you can rename the DLL from your mod and set
 			its new name here. Empty by default. For example, if the preloader uses 'IpHlpAPI.dll' and your mod uses
 			the same DLL, rename the DLL from your mod to something else like 'IpHlpAPI MyMod.dll' and set the option to:
-			
+
 			<OriginalLibrary>IpHlpAPI MyMod.dll</OriginalLibrary>
 		-->
 		<OriginalLibrary/>
-		
+
 		<!-- Load method for xSE plugins, 'ImportAddressHook' by default. Don't change unless required. -->
 		<LoadMethod Name="ImportAddressHook">
 			<!--
@@ -19,15 +19,15 @@
 				## Description:
 					Sets an import table hook for the specified function inside DLL loaded by the host process.
 					When the hook is called, it'll load plugins and then it'll get back to its usual operations.
-					
+
 					Uses Detours library by Nukem: https://github.com/Nukem9/detours
-					
+
 				## Remarks:
 					### Fallout 4:
 						LibraryName: MSVCR110.dll
 						FunctionName: _initterm_e
 							The function *must* have a signature compatible with 'void*(__cdecl*)(void*, void*)'.
-					
+
 					### Skyrim (Legendary Edition):
 						LibraryName: kernel32.dll
 						FunctionName: GetCommandLineA
@@ -37,7 +37,7 @@
 						LibraryName: api-ms-win-crt-runtime-l1-1-0.dll
 						FunctionName: _initterm_e
 							The function *must* have a signature compatible with 'void*(__cdecl*)(void*, void*)'.
-					
+
 				## Parameters:
 					- LibraryName: The name of a DLL that contains the function to hook.
 					- FunctionName: Name of the function to hook. Must be exported from a DLL pointed by the 'LibraryName' parameter.
@@ -46,7 +46,7 @@
 				<LibraryName></LibraryName>
 				<FunctionName></FunctionName>
 			</ImportAddressHook>
-			
+
 			<!--
 				# OnThreadAttach
 
@@ -54,12 +54,12 @@
 					Same as 'OnProcessAttach' above, but loads plugins after certain number of threads have been created
 					by the host process (inside 'DLL_THREAD_ATTACH' notification). This methods has all the disadvantages
 					of the previous one but it can be triggered too late.
-				
+
 				## Remarks:
 					The method mainly designed for Mod Organizer 2 (MO2) to give some time to its virtual file system to
 					initialize itself, otherwise there will be no plugins to preload if they're installed as MO2 virtual
 					mods.
-				
+
 				## Parameters:
 					- ThreadNumber: Specifies a thread number which will trigger the loading. That is, when the value is '2',
 					the second attached thread will trigger the loading process. Negative numbers are not allowed.
@@ -76,10 +76,10 @@
 					In other words, right after the host process starts. Executing certain kinds of code inside 'DLLMain' is
 					risky (see: https://docs.microsoft.com/ru-ru/windows/win32/dlls/dynamic-link-library-best-practices#general-best-practices)
 					so this method may fail in some cases.
-				
+
 				## Remarks:
 					The preloader calls 'DisableThreadLibraryCalls' when it's done interfacing with 'DLLMain' thread notifications.
-				
+
 				## Parameters:
 					<None>
 			-->
@@ -100,13 +100,13 @@
 			# LoadDelay
 			Sets the amount of time the preloader will pause the loading thread, in milliseconds. 0 means no delay.
 			Don't change unless you need some time to attach debugger before loading starts, for example.
-			
+
 			# HookDelay
 			HookDelay works only for 'ImportAddressHook' methods and additionally waits before hooking the required function.
 		-->
 		<LoadDelay>0</LoadDelay>
 		<HookDelay>0</HookDelay>
-		
+
 		<!--
 			# Processes
 
@@ -118,13 +118,13 @@
 			<Item Name="FalloutNV.exe" Allow="false"/>
 			<Item Name="Fallout4.exe" Allow="true"/>
 			<Item Name="Fallout4VR.exe" Allow="true"/>
-			
+
 			<Item Name="Morrowind.exe" Allow="false"/>
 			<Item Name="Oblivion.exe" Allow="false"/>
 			<Item Name="TESV.exe" Allow="true"/>
 			<Item Name="SkyrimSE.exe" Allow="true"/>
 			<Item Name="SkyrimVR.exe" Allow="true"/>
-			
+
 			<Item Name="TESConstructionSet.exe" Allow="false"/>
 			<Item Name="CreationKit.exe" Allow="false"/>
 		</Processes>


### PR DESCRIPTION
* There were quite a few lines with excess leading whitespace and
  another content. This usually upsets editors and/or IDEs which are set
  to display this as an error - plus it's just bad to have around.